### PR TITLE
add iso_basic method for iTSms and iTSus with millisecond and microsecond precision

### DIFF
--- a/tests/test_ts.py
+++ b/tests/test_ts.py
@@ -927,6 +927,14 @@ class Test_iTSms(TestCase):
     def test_from_iso(self):
         run_test_from_iso(self, iTSms)
 
+    def test_regression_iso_basic_precision(self):
+        its = iTSms("2025-10-07T13:11:21.098Z")
+        self.assertEqual("2025-10-07T13:11:21.098Z", its.isoformat())
+        self.assertEqual("20251007T131121.098Z", its.iso_basic(sep="T"))
+        self.assertEqual("20251007T131121.098", its.iso_basic(sep="T", use_zulu=False))
+        self.assertEqual("20251007-131121.098Z", its.iso_basic())
+        self.assertEqual("20251007-131121.098", its.iso_basic(use_zulu=False))
+
     def test_error_message_regression(self):
         a = "invalid-timestamp"
         with self.assertRaises(ValueError) as e:
@@ -1055,6 +1063,14 @@ class Test_iTSms(TestCase):
 class Test_iTSus(TestCase):
     def test_from_iso(self):
         run_test_from_iso(self, iTSus)
+
+    def test_regression_iso_basic_precision(self):
+        its = iTSus("2025-10-07T13:11:21.098321Z")
+        self.assertEqual("2025-10-07T13:11:21.098321Z", its.isoformat())
+        self.assertEqual("20251007T131121.098321Z", its.iso_basic(sep="T"))
+        self.assertEqual("20251007T131121.098321", its.iso_basic(sep="T", use_zulu=False))
+        self.assertEqual("20251007-131121.098321Z", its.iso_basic())
+        self.assertEqual("20251007-131121.098321", its.iso_basic(use_zulu=False))
 
     def test_itsus_ms_regression(self):
         """ ensures that when the ts has ms precision, we don't add float imprecision/add extra digits when converting to ns """

--- a/tsx/ts.py
+++ b/tsx/ts.py
@@ -1319,6 +1319,16 @@ class iTSms(iBaseTS):
         """
         return "milliseconds"
 
+    def iso_basic(self, sep="-", use_zulu: bool = True) -> str:
+        """
+        Returns Basic ISO date format with millisecond precision, like: 20210101-000000.123Z
+        When (sep='T', use_zulu=False) produces: 20210101T131121.098
+        """
+        seconds, ms = divmod(self, 1_000)
+        zulu_designator = "Z" if use_zulu else ""
+        dt = datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=seconds)
+        return dt.strftime(f"%Y%m%d{sep}%H%M%S.{ms:03d}{zulu_designator}")
+
 
 class iTSus(iBaseTS):
     """
@@ -1379,6 +1389,16 @@ class iTSus(iBaseTS):
             assert isinstance(tz, dt_tzinfo)
             dt = datetime(1970, 1, 1, tzinfo=tz) + timedelta(seconds=seconds, microseconds=us)
         return dt
+
+    def iso_basic(self, sep="-", use_zulu: bool = True) -> str:
+        """
+        Returns Basic ISO date format with microsecond precision, like: 20210101-000000.123456Z
+        When (sep='T', use_zulu=False) produces: 20210101T131121.098321
+        """
+        seconds, us = divmod(self, 1_000_000)
+        zulu_designator = "Z" if use_zulu else ""
+        dt = datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=seconds)
+        return dt.strftime(f"%Y%m%d{sep}%H%M%S.{us:06d}{zulu_designator}")
 
 
 class iTSns(iBaseTS):


### PR DESCRIPTION
they relied on base's `iso_basic`